### PR TITLE
Update links to projectfluent

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ fluent-kotlin
 
 The `fluent` project contains packages to
 bring `Project Fluent <https://projectfluent.org>`__ to Kotlin and Java.
-Visit the `Github project <https://github.com/Pike/fluent-kotlin>`__
+Visit the `Github project <https://github.com/projectfluent/fluent-kotlin>`__
 for the full list.
 
 org.projectfluent:syntax
@@ -17,4 +17,4 @@ processing of Fluent files.
    :caption: Packages
    :maxdepth: 1
 
-   org.projectfluent:syntax <https://pike.github.io/fluent-kotlin/fluent.syntax/>
+   org.projectfluent:syntax <https://projectfluent.org/fluent-kotlin/fluent.syntax/>

--- a/fluent.syntax/README.rst
+++ b/fluent.syntax/README.rst
@@ -24,4 +24,4 @@ if you work on tooling for Fluent in Kotlin or Java.
 
 
 .. _fluent: https://projectfluent.org/
-.. |fluent.syntax| image:: https://github.com/Pike/fluent-kotlin/workflows/fluent.syntax/badge.svg
+.. |fluent.syntax| image:: https://github.com/projectfluent/fluent-kotlin/workflows/fluent.syntax/badge.svg


### PR DESCRIPTION
fluent-kotlin is transferred to projectfluent.org.

CC @MikkCZ so that you know ;-).

Nothing much changed than the upstream.