### PR TITLE
Serializer can write to directly to provided output (e.g. stream or single StringBuilder)

### DIFF
--- a/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/serializer/FluentParserAndSerializerTest.kt
+++ b/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/serializer/FluentParserAndSerializerTest.kt
@@ -6,55 +6,56 @@ import org.projectfluent.syntax.ast.Resource
 import org.projectfluent.syntax.parser.FluentParser
 import java.io.ByteArrayOutputStream
 
-class SerializeResourceTest {
+class FluentParserAndSerializerTest {
+
     private val parser = FluentParser()
     private val serializer = FluentSerializer()
 
-    private fun pretty(input: String): String {
-        val resource = this.parser.parse(input)
-        val serialized = this.serializer.serialize(resource)
+    private fun parseAndSerialize(input: String): String {
+        val resource = parser.parse(input)
+        val serialized = serializer.serialize(resource)
         return serialized.toString()
     }
 
     @Test
-    fun simple_message_without_eol() {
+    fun simpleMessageWithoutEol() {
         val input = "foo = Foo"
-        assertEquals("foo = Foo\n", this.pretty(input))
+        assertEquals("foo = Foo\n", parseAndSerialize(input))
     }
 
     @Test
-    fun simple_message() {
+    fun simpleMessage() {
         val input =
             """
             foo = Foo
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun simple_term() {
+    fun simpleTerm() {
         val input =
             """
             -foo = Foo
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun two_simple_messages() {
+    fun twoSimpleMessages() {
         val input =
             """
             foo = Foo
             bar = Bar
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun block_multiline_message() {
+    fun blockMultilineMessage() {
         val input =
             """
             foo =
@@ -62,11 +63,11 @@ class SerializeResourceTest {
                 Bar
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun inline_multiline_message() {
+    fun inlineMultilineMessage() {
         val input =
             """
             foo = Foo
@@ -80,71 +81,71 @@ class SerializeResourceTest {
                 Bar
             
             """.trimIndent()
-        assertEquals(expected, this.pretty(input))
+        assertEquals(expected, parseAndSerialize(input))
     }
 
     @Test
-    fun message_reference() {
+    fun messageReference() {
         val input =
             """
             foo = Foo { bar }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun message_attribute_reference() {
+    fun messageAttributeReference() {
         val input =
             """
             foo = Foo { bar.baz }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun term_reference() {
+    fun termReference() {
         val input =
             """
             foo = Foo { -bar }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun variable_reference() {
+    fun variableReference() {
         val input =
             """
             foo = Foo { ${'$'}bar }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun number_literal() {
+    fun numberLiteral() {
         val input =
             """
             foo = Foo { 1 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun string_literal() {
+    fun stringLiteral() {
         val input =
             """
             foo = Foo { "bar" }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun resource_comment() {
+    fun resourceComment() {
         val input =
             """
             ### A multiline
@@ -153,11 +154,11 @@ class SerializeResourceTest {
             foo = Foo
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun group_comment() {
+    fun groupComment() {
         val input =
             """
             foo = Foo
@@ -170,11 +171,11 @@ class SerializeResourceTest {
             bar = Bar
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun message_comment() {
+    fun messageComment() {
         val input =
             """
             # A multiline
@@ -182,11 +183,11 @@ class SerializeResourceTest {
             foo = Foo
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun standalone_comment() {
+    fun standaloneComment() {
         val input =
             """
             foo = Foo
@@ -196,11 +197,11 @@ class SerializeResourceTest {
             bar = Bar
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun multiline_with_placeable() {
+    fun multilineWithPlaceable() {
         val input =
             """
             foo =
@@ -208,7 +209,7 @@ class SerializeResourceTest {
                 Baz
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
@@ -219,11 +220,11 @@ class SerializeResourceTest {
                 .attr = Foo Attr
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun multiline_attribute() {
+    fun multilineAttribute() {
         val input =
             """
             foo =
@@ -232,11 +233,11 @@ class SerializeResourceTest {
                     Continued
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun two_attribute() {
+    fun twoAttribute() {
         val input =
             """
             foo =
@@ -244,11 +245,11 @@ class SerializeResourceTest {
                 .attr-b = Foo Attr B
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun value_and_attributes() {
+    fun valueAndAttributes() {
         val input =
             """
             foo = Foo Value
@@ -256,11 +257,11 @@ class SerializeResourceTest {
                 .attr-b = Foo Attr B
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun multiline_value_and_attributes() {
+    fun multilineValueAndAttributes() {
         val input =
             """
             foo =
@@ -270,11 +271,11 @@ class SerializeResourceTest {
                 .attr-b = Foo Attr B
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun select_expression() {
+    fun selectExpression() {
         val input =
             """
             foo =
@@ -284,11 +285,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun multiline_variant() {
+    fun multilineVariant() {
         val input =
             """
             foo =
@@ -299,11 +300,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun multiline_variant_with_first_line_inline() {
+    fun multilineVariantWithFirstLineInline() {
         val input =
             """
             foo =
@@ -323,11 +324,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(expected, this.pretty(input))
+        assertEquals(expected, parseAndSerialize(input))
     }
 
     @Test
-    fun variant_key_number() {
+    fun variantKeyNumber() {
         val input =
             """
             foo =
@@ -336,11 +337,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun select_expression_in_block_pattern() {
+    fun selectExpressionInBlockPattern() {
         val input =
             """
             foo =
@@ -350,11 +351,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun select_expression_in_inline_pattern() {
+    fun selectExpressionInInlinePattern() {
         val input =
             """
             foo = Foo { ${'$'}sel ->
@@ -372,11 +373,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(expected, this.pretty(input))
+        assertEquals(expected, parseAndSerialize(input))
     }
 
     @Test
-    fun select_expression_in_multiline_pattern() {
+    fun selectExpressionInMultilinePattern() {
         val input =
             """
             foo =
@@ -387,11 +388,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun nested_select_expression() {
+    fun nestedSelectExpression() {
         val input =
             """
             foo =
@@ -403,11 +404,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun selector_variable_reference() {
+    fun selectorVariableReference() {
         val input =
             """
             foo =
@@ -416,11 +417,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun selector_number_literal() {
+    fun selectorNumberLiteral() {
         val input =
             """
             foo =
@@ -429,11 +430,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun selector_string_literal() {
+    fun selectorStringLiteral() {
         val input =
             """
             foo =
@@ -442,11 +443,11 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun selector_term_attribute_reference() {
+    fun selectorTermAttributeReference() {
         val input =
             """
             foo =
@@ -455,157 +456,157 @@ class SerializeResourceTest {
                 }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression() {
+    fun callExpression() {
         val input =
             """
             foo = { FOO() }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_string_literal() {
+    fun callExpressionWithStringLiteral() {
         val input =
             """
             foo = { FOO("bar") }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_number_literal() {
+    fun callExpressionWithNumberLiteral() {
         val input =
             """
             foo = { FOO(1) }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_message_reference() {
+    fun callExpressionWithMessageReference() {
         val input =
             """
             foo = { FOO(bar) }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_variable_reference() {
+    fun callExpressionWithVariableReference() {
         val input =
             """
             foo = { FOO(${'$'}bar) }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_named_number_literal() {
+    fun callExpressionWithNamedNumberLiteral() {
         val input =
             """
             foo = { FOO(bar: 1) }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_named_string_literal() {
+    fun callExpressionWithNamedStringLiteral() {
         val input =
             """
             foo = { FOO(bar: "bar") }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_two_positional_arguments() {
+    fun callExpressionWithTwoPositionalArguments() {
         val input =
             """
             foo = { FOO(bar, baz) }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_two_named_arguments() {
+    fun callExpressionWithTwoNamedArguments() {
         val input =
             """
             foo = { FOO(bar: "bar", baz: "baz") }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun call_expression_with_positional_and_named_arguments() {
+    fun callExpressionWithPositionalAndNamedArguments() {
         val input =
             """
             foo = { FOO(bar, 1, baz: "baz") }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun term_reference_call() {
+    fun termReferenceCall() {
         val input =
             """
             foo = { -term() }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun nested_placeable() {
+    fun nestedPlaceable() {
         val input =
             """
             foo = {{ FOO() }}
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun backslash_in_text_element() {
+    fun backslashInTextElement() {
         val input =
             """
             foo = \{ placeable }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun escaped_special_char_in_string_literal() {
+    fun escapedSpecialCharInStringLiteral() {
         val input =
             """
             foo = { "Escaped \" quote" }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
-    fun unicode_escape_sequence() {
+    fun unicodeEscapeSequence() {
         val input =
             """
             foo = { "\u0065" }
             
             """.trimIndent()
-        assertEquals(input, this.pretty(input))
+        assertEquals(input, parseAndSerialize(input))
     }
 
     @Test
@@ -630,7 +631,7 @@ class SerializeResourceTest {
         val input = "foo = Foo"
         val resource: Resource = parser.parse(input)
 
-        val expected = this.serializer.serialize(resource)
+        val expected = serializer.serialize(resource)
         val actual = with(
             ByteArrayOutputStream(),
             {


### PR DESCRIPTION
follow-up from discussion in #35

This basically replaces all `return`s, intermediate string builders/concatenation/interpolation by calling some result collector, that can be implemented by StringBuilder, OutputStream, writing to standard output, or any combination of them.