### PR TITLE
Archive jar artifacts built by the CI

### DIFF
--- a/.github/workflows/fluent.syntax.yml
+++ b/.github/workflows/fluent.syntax.yml
@@ -26,7 +26,12 @@ jobs:
         java-version: 1.8
     - name: Build and check
       working-directory: ./fluent.syntax
-      run: ./gradlew test
+      run: ./gradlew build
+    - name: Archive build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: org.projectfluent.syntax
+        path: ./fluent.syntax/build/libs/*.jar
   lint:
     name: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
The artifacts are stored by GitHub for 90 days. Here's an example job with its artifact: https://github.com/projectfluent/fluent-kotlin/actions/runs/246816407