### PR TITLE
Don't drop to newline when serializing patterns starting with special chars

### DIFF
--- a/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/serializer/SerializeResourceTest.kt
+++ b/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/serializer/SerializeResourceTest.kt
@@ -203,6 +203,35 @@ class SerializeResourceTest {
     }
 
     @Test
+    fun multiline_starting_inline() {
+        val input =
+            """
+            foo = Foo
+                Baz
+            
+            """.trimIndent()
+        val output =
+            """
+            foo =
+                Foo
+                Baz
+            
+            """.trimIndent()
+        assertEquals(output, this.pretty(input))
+    }
+
+    @Test
+    fun multiline_starting_inline_with_a_special_char() {
+        val input =
+            """
+            foo = *Foo
+                Baz
+            
+            """.trimIndent()
+        assertEquals(input, this.pretty(input))
+    }
+
+    @Test
     fun multiline_with_placeable() {
         val input =
             """
@@ -376,6 +405,19 @@ class SerializeResourceTest {
             
             """.trimIndent()
         assertEquals(expected, this.pretty(input))
+    }
+
+    @Test
+    fun select_expression_in_inline_pattern_starting_with_a_special_char() {
+        val input =
+            """
+            foo = .Foo { ${'$'}sel ->
+                   *[a] A
+                    [b] B
+                }
+            
+            """.trimIndent()
+        assertEquals(input, this.pretty(input))
     }
 
     @Test

--- a/fluent.syntax/src/test/resources/reference_fixtures/special_chars.ftl
+++ b/fluent.syntax/src/test/resources/reference_fixtures/special_chars.ftl
@@ -1,0 +1,14 @@
+## OK
+
+bracket-inline = [Value]
+dot-inline = .Value
+star-inline = *Value
+
+## ERRORS
+
+bracket-newline =
+    [Value]
+dot-newline =
+    .Value
+star-newline =
+    *Value

--- a/fluent.syntax/src/test/resources/reference_fixtures/special_chars.json
+++ b/fluent.syntax/src/test/resources/reference_fixtures/special_chars.json
@@ -1,0 +1,82 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "GroupComment",
+            "content": "OK"
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "bracket-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "[Value]"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "dot-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": ".Value"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "star-inline"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "*Value"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "GroupComment",
+            "content": "ERRORS"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "bracket-newline =\n    [Value]\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "dot-newline =\n    .Value\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "star-newline =\n    *Value\n"
+        }
+    ]
+}


### PR DESCRIPTION
A port of https://github.com/projectfluent/fluent.js/pull/513.