### PR TITLE
Support UXXXXXX escape sequences

### DIFF
--- a/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/processor/Processor.kt
+++ b/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/processor/Processor.kt
@@ -1,7 +1,6 @@
 package org.projectfluent.syntax.processor
 
 import org.projectfluent.syntax.ast.* // ktlint-disable no-wildcard-imports
-import java.lang.Exception
 import java.lang.StringBuilder
 
 /**
@@ -161,7 +160,10 @@ class Processor {
         if (uni4 != "") {
             val codepoint = uni4.substring(1).toInt(16)
             if (Character.isBmpCodePoint(codepoint)) {
-                return codepoint.toChar().toString()
+                val char = codepoint.toChar()
+                if (!Character.isSurrogate(char)) {
+                    return char.toString()
+                }
             }
         }
 
@@ -169,13 +171,16 @@ class Processor {
         if (uni6 != "") {
             val codepoint = uni6.substring(1).toInt(16)
             if (Character.isValidCodePoint(codepoint)) {
-                val builder = StringBuilder()
-                builder.append(Character.highSurrogate(codepoint))
-                builder.append(Character.lowSurrogate(codepoint))
-                return builder
+                val char = codepoint.toChar()
+                if (!Character.isSurrogate(char)) {
+                    val builder = StringBuilder()
+                    builder.append(Character.highSurrogate(codepoint))
+                    builder.append(Character.lowSurrogate(codepoint))
+                    return builder
+                }
             }
         }
 
-        throw Exception("Unexpected")
+        return "�"
     }
 }

--- a/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/processor/Processor.kt
+++ b/fluent.syntax/src/main/kotlin/org/projectfluent/syntax/processor/Processor.kt
@@ -37,7 +37,7 @@ class Processor {
             when (element) {
                 is TextElement -> {
                     if (lastText == null) {
-                        lastText = element
+                        lastText = TextElement(element.value)
                     } else {
                         lastText?.let { it.value += element.value }
                     }

--- a/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/processor/ProcessorTest.kt
+++ b/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/processor/ProcessorTest.kt
@@ -84,6 +84,30 @@ internal class ProcessorTest {
         pattern.elements.clear()
         pattern.elements.addAll(
             arrayOf(
+                TextElement("Illegal escape sequence: "),
+                Placeable(expression = StringLiteral("""\ud800"""))
+            )
+        )
+        assertEquals(
+            Pattern(TextElement("Illegal escape sequence: �")),
+            processor.unescapeLiteralsToText(pattern)
+        )
+
+        pattern.elements.clear()
+        pattern.elements.addAll(
+            arrayOf(
+                TextElement("Illegal escape sequence: "),
+                Placeable(expression = StringLiteral("""\U00d800"""))
+            )
+        )
+        assertEquals(
+            Pattern(TextElement("Illegal escape sequence: �")),
+            processor.unescapeLiteralsToText(pattern)
+        )
+
+        pattern.elements.clear()
+        pattern.elements.addAll(
+            arrayOf(
                 TextElement("Hi, "),
                 Placeable(expression = StringLiteral("""{""")),
                 TextElement(" there")

--- a/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/processor/ProcessorTest.kt
+++ b/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/processor/ProcessorTest.kt
@@ -35,6 +35,26 @@ internal class ProcessorTest {
         pattern.elements.clear()
         pattern.elements.addAll(
             arrayOf(
+                TextElement("Foo "),
+                Placeable(expression = StringLiteral("Bar"))
+            )
+        )
+        assertEquals(
+            Pattern(TextElement("Foo Bar")),
+            processor.unescapeLiteralsToText(pattern)
+        )
+        // The original Pattern isn't modified.
+        assertEquals(
+            Pattern(
+                TextElement("Foo "),
+                Placeable(expression = StringLiteral("Bar"))
+            ),
+            pattern
+        )
+
+        pattern.elements.clear()
+        pattern.elements.addAll(
+            arrayOf(
                 TextElement("Hi,"),
                 Placeable(expression = StringLiteral("""\u0020""")),
                 TextElement("there")

--- a/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/processor/ProcessorTest.kt
+++ b/fluent.syntax/src/test/kotlin/org/projectfluent/syntax/processor/ProcessorTest.kt
@@ -68,6 +68,22 @@ internal class ProcessorTest {
         pattern.elements.clear()
         pattern.elements.addAll(
             arrayOf(
+                TextElement("Emoji: "),
+                Placeable(expression = StringLiteral("""\U01f602"""))
+            )
+        )
+        assertEquals(
+            Pattern(TextElement("Emoji: \uD83D\uDE02")),
+            processor.unescapeLiteralsToText(pattern)
+        )
+        assertEquals(
+            Pattern(TextElement("Emoji: 😂")),
+            processor.unescapeLiteralsToText(pattern)
+        )
+
+        pattern.elements.clear()
+        pattern.elements.addAll(
+            arrayOf(
                 TextElement("Hi, "),
                 Placeable(expression = StringLiteral("""{""")),
                 TextElement(" there")


### PR DESCRIPTION
This adds support to baking Fluent's `\U123456` unicode escape sequences. Fixes #44.

While testing this I discovered that the `lastText` logic in `Processor.textFromLiterals` was modifying the value of the original Pattern's element in some cases. I realized this was the case when I couldn't run the same assert twice. The first commit in the PR fixes this. Now, the processed pattern will always consist of new `TextElement` instances. OTOH, `Placeables` are copied by reference, still. (I wish we had `clone()`.)